### PR TITLE
Update the trigger for the changelog action

### DIFF
--- a/.github/workflows/changelog-update.yml
+++ b/.github/workflows/changelog-update.yml
@@ -2,9 +2,9 @@ name: CHANGELOG
 
 on:
   push:
-    branches:
-      - '**changelog**'
-
+    paths:
+      - 'src/changelogs/web/CHANGELOG.md'
+      - 'src/changelogs/components/CHANGELOG.md'
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/changelog-update.yml
+++ b/.github/workflows/changelog-update.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Pull Request
+      - name: Create Pull Request
         uses: repo-sync/pull-request@v2
         with:
           destination_branch: "main"

--- a/.github/workflows/changelog-update.yml
+++ b/.github/workflows/changelog-update.yml
@@ -6,12 +6,12 @@ on:
       - 'src/changelogs/web/CHANGELOG.md'
       - 'src/changelogs/components/CHANGELOG.md'
 jobs:
-  build:
+  create-pull-request:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
-      - name: pull-request
+      - name: Pull Request
         uses: repo-sync/pull-request@v2
         with:
           destination_branch: "main"


### PR DESCRIPTION
The changelog action would previously trigger whenever the word "changelog" was a substring of the feature branch. This has been changed such that the job is now triggered whenever the CHANGELOG.md file at a given path is changed.