### PR TITLE
Link directly to class index in iOS reference documentation

### DIFF
--- a/src/_includes/sidebar.njk
+++ b/src/_includes/sidebar.njk
@@ -22,7 +22,7 @@
   {% endif %}
   {% if ('ios/v3/' in page.url) and ('changelogs' not in page.url) %}
    <p class="sidebar__header"><a href="/ios/v3/">iOS v3</p>
-    <a href="https://app.mapsindoors.com/mapsindoors/reference/ios/v3/index.html">Reference Docs
+    <a href="https://app.mapsindoors.com/mapsindoors/reference/ios/v3/classes.html">Reference Docs
       &UpperRightArrow;</a>
     <hr />
     {% set navPages = collections.published | eleventyNavigation("ios-v3") %}


### PR DESCRIPTION
Link directly to class index in iOS reference documentation to avoid coming to almost blank page